### PR TITLE
plugin/node.js: don’t overwrite already-set variables

### DIFF
--- a/plugins/available/nenv.plugin.bash
+++ b/plugins/available/nenv.plugin.bash
@@ -4,11 +4,10 @@ about-plugin 'Node.js environment management using https://github.com/ryuone/nen
 # Load after basher
 # BASH_IT_LOAD_PRIORITY: 260
 
-export NENV_ROOT="${NENV_ROOT:-${HOME?}/.nenv}"
+: "${NENV_ROOT:=${HOME?}/.nenv}"
+export NENV_ROOT
 
-if [[ -d "${NENV_ROOT?}/bin" ]]; then
-	pathmunge "${NENV_ROOT?}/bin"
-fi
+pathmunge "${NENV_ROOT?}/bin"
 
 if _command_exists nenv; then
 	eval "$(nenv init - bash)"

--- a/plugins/available/nodenv.plugin.bash
+++ b/plugins/available/nodenv.plugin.bash
@@ -4,11 +4,10 @@ about-plugin 'Node.js environment management using https://github.com/nodenv/nod
 # Load after basher
 # BASH_IT_LOAD_PRIORITY: 260
 
-export NODENV_ROOT="${NODENV_ROOT:-${HOME?}/.nodenv}"
+: "${NODENV_ROOT:=${HOME?}/.nodenv}"
+export NODENV_ROOT
 
-if [[ -d "${NODENV_ROOT?}/bin" ]]; then
-	pathmunge "${NODENV_ROOT?}/bin"
-fi
+pathmunge "${NODENV_ROOT?}/bin"
 
 if _command_exists nodenv; then
 	eval "$(nodenv init - bash)"

--- a/plugins/available/nvm.plugin.bash
+++ b/plugins/available/nvm.plugin.bash
@@ -4,7 +4,8 @@ about-plugin 'Node.js version manager, https://github.com/nvm-sh/nvm'
 # Load after basher
 # BASH_IT_LOAD_PRIORITY: 260
 
-export NVM_DIR="${NVM_DIR:-${HOME?}/.nvm}"
+: "${NVM_DIR:=${HOME?}/.nvm}"
+export NVM_DIR
 
 if _bash_it_homebrew_check && [[ -s "${BASH_IT_HOMEBREW_PREFIX?}/nvm.sh" ]]; then
 	source "${BASH_IT_HOMEBREW_PREFIX?}/nvm.sh"


### PR DESCRIPTION
## Description
plugin/node.js: don’t overwrite environment variables that the user may have already set:
- `$NENV_ROOT`
- `$NODENV_ROOT`
- `$NVM_DIR`

Alsö, no need to check if directory exists before calling `pathmunge` as it already does so.

## Motivation and Context
Just helping out 👍 

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
